### PR TITLE
fix a bug on Array.inl which was caused by no suitable conversion fro…

### DIFF
--- a/src/Core/Array/Array.inl
+++ b/src/Core/Array/Array.inl
@@ -76,7 +76,7 @@ namespace dyno
 	template<typename T>
 	void Array<T, DeviceType::GPU>::assign(const std::vector<T>& src, const uint count, const uint dstOffset, const uint srcOffset)
 	{
-		cuSafeCall(cudaMemcpy(mData + dstOffset, src.begin() + srcOffset, count * sizeof(T), cudaMemcpyHostToDevice));
+		cuSafeCall(cudaMemcpy(mData + dstOffset, src.data() + srcOffset, count * sizeof(T), cudaMemcpyHostToDevice));
 	}
 
 	template<typename T>


### PR DESCRIPTION
previous compile error when calling this function:
![19d172fa72c539976b6222efeda641a](https://user-images.githubusercontent.com/53465084/215454457-003ff54f-eaa3-4917-9ff5-dd4dacccb86c.png)
now is fixed.