### PR TITLE
Pybind_Task_1_20230727

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 link_libraries(Core Framework IO)
 link_libraries(GlfwGUI)
-link_libraries(ParticleSystem RigidBody Peridynamics GLRenderEngine)
+link_libraries(ParticleSystem RigidBody Peridynamics GLRenderEngine Modeling Topology)
 
 file(COPY "Testing/" DESTINATION ${CMAKE_BINARY_DIR}/bin/Debug)
 file(COPY "Testing/" DESTINATION ${CMAKE_BINARY_DIR}/bin/Release)

--- a/python/PyFramework.cpp
+++ b/python/PyFramework.cpp
@@ -15,8 +15,16 @@
 #include "Topology/EdgeSet.h"
 
 #include "Module/TopologyMapping.h"
+#include "PlaneModel.h"
+#include "SphereModel.h"
 
 #include "Mapping/DiscreteElementsToTriangleSet.h"
+
+
+#include "ParticleSystem/ParticleSystem.h"
+#include "ParticleSystem/Module/ParticleIntegrator.h"
+#include "ParticleSystem/Module/ImplicitViscosity.h"
+
 
 #include "SceneGraph.h"
 #include "Log.h"
@@ -138,6 +146,103 @@ void declare_discrete_topology_mapping(py::module& m, std::string typestr) {
 	py::class_<Class, Parent, std::shared_ptr<Class>>(m, pyclass_name.c_str());
 }
 
+
+//------------------------- New ------------------------------
+
+#include "SphereModel.h"
+template <typename TDataType>
+void declare_sphere_model(py::module& m, std::string typestr) {
+	using Class = dyno::SphereModel<TDataType>;
+	using Parent = dyno::ParametricModel<TDataType>;
+	std::string pyclass_name = std::string("SphereModel") + typestr;
+	py::class_<Class, Parent, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def("var_scale", &Class::varScale, py::return_value_policy::reference)
+		.def("var_location", &Class::varLocation, py::return_value_policy::reference)
+		.def("state_triangleSet", &Class::stateTriangleSet, py::return_value_policy::reference);
+
+}
+
+template <typename TDataType>
+void declare_parametric_model(py::module& m, std::string typestr) {
+	using Class = dyno::ParametricModel<TDataType>;
+	using Parent = dyno::Node;
+	std::string pyclass_name = std::string("ParametricModel") + typestr;
+	py::class_<Class, Parent, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>());
+}
+
+
+#include "PlaneModel.h"
+template <typename TDataType>
+void declare_plane_model(py::module& m, std::string typestr) {
+	using Class = dyno::PlaneModel<TDataType>;
+	using Parent = dyno::ParametricModel<TDataType>;
+	std::string pyclass_name = std::string("PlaneModel") + typestr;
+	py::class_<Class, Parent, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def("var_scale", &Class::varScale, py::return_value_policy::reference)
+		.def("state_triangleSet", &Class::stateTriangleSet, py::return_value_policy::reference);
+		
+}
+
+#include "Mapping/MergeTriangleSet.h"
+template <typename TDataType>
+void declare_merge_triangle_set(py::module& m, std::string typestr) {
+	using Class = dyno::MergeTriangleSet<TDataType>;
+	using Parent = dyno::Node;
+	std::string pyclass_name = std::string("MergeTriangleSet") + typestr;
+	py::class_<Class, Parent, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def("state_triangleSet", &Class::stateTriangleSet, py::return_value_policy::reference)
+		.def("in_first", &Class::inFirst, py::return_value_policy::reference)
+		.def("in_second", &Class::inSecond, py::return_value_policy::reference);
+
+}
+
+#include "SemiAnalyticalScheme/SemiAnalyticalSFINode.h"
+template <typename TDataType>
+void declare_semiAnalyticalSFI_node(py::module& m, std::string typestr) {
+	using Class = dyno::SemiAnalyticalSFINode<TDataType>;
+	using Parent = dyno::Node;
+	std::string pyclass_name = std::string("SemiAnalyticalSFINode") + typestr;
+	py::class_<Class, Parent, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def("import_particle_systems", &Class::importParticleSystems, py::return_value_policy::reference)
+		.def("in_triangleSet", &Class::inTriangleSet, py::return_value_policy::reference);
+}
+
+//Init_static_plugin  - for example_3 WaterPouring
+#include "initializeModeling.h"
+#include "ParticleSystem/initializeParticleSystem.h"
+#include "SemiAnalyticalScheme/initializeSemiAnalyticalScheme.h"
+void declare_modeling_init_static_plugin(py::module& m,std::string typestr) {
+	using Class = dyno::ModelingInitializer;
+	using Parent = dyno::PluginEntry;
+	std::string pyclass_name = std::string("ModelingInitializer" + typestr);
+	py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def("modeling_init_static_plugin", &Modeling::initStaticPlugin);
+}
+
+void declare_paticleSystem_init_static_plugin(py::module& m, std::string typestr) {
+	using Class = dyno::ParticleSystemInitializer;
+	using Parent = dyno::PluginEntry;
+	std::string pyclass_name = std::string("ParticleSystemInitializer" + typestr);
+	py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def("paticleSystem_init_static_plugin", &PaticleSystem::initStaticPlugin);
+}
+/*
+void declare_semiAnalyticalScheme_init_static_plugin(py::module& m, std::string typestr) {
+	using Class = dyno::SemiAnalyticalSchemeInitializer;
+	using Parent = dyno::PluginEntry;
+	std::string pyclass_name = std::string("SemiAnalyticalSchemeInitializer" + typestr);
+	py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def("semiAnalyticalScheme_init_static_plugin", &SemiAnalyticalScheme::initStaticPlugin);
+}*/
+
+//------------------------- NEW END ------------------------------
+
+
 void pybind_framework(py::module& m)
 {
 	pybind_log(m);
@@ -217,6 +322,19 @@ void pybind_framework(py::module& m)
 	declare_instance<dyno::EdgeSet<dyno::DataType3f>>(m, "EdgeSet3f");
 	declare_instance<dyno::TriangleSet<dyno::DataType3f>>(m, "TriangleSet3f");
 	declare_instance<dyno::DiscreteElements<dyno::DataType3f>>(m, "DiscreteElements3f");
+
+
+    // New
+	declare_parametric_model<dyno::DataType3f>(m, "3f");
+	declare_plane_model<dyno::DataType3f>(m, "3f");
+	declare_sphere_model<dyno::DataType3f>(m, "3f");
+	declare_merge_triangle_set<dyno::DataType3f>(m, "3f");
+
+	declare_semiAnalyticalSFI_node<dyno::DataType3f>(m, "3f");
+
+	declare_modeling_init_static_plugin(m,"");
+	declare_paticleSystem_init_static_plugin(m,"");
+	//declare_semiAnalyticalScheme_init_static_plugin(m, "");
 
 
 }

--- a/python/PyParticleSystem.cpp
+++ b/python/PyParticleSystem.cpp
@@ -8,9 +8,11 @@
 #include "Peridynamics/ElasticBody.h"
 #include "Peridynamics/Module/ElasticityModule.h"
 
-
+#include "ParticleSystem/CircularEmitter.h"
 
 #include "RigidBody/RigidBody.h"
+
+
 
 using Node = dyno::Node;
 using NodePort = dyno::NodePort;
@@ -80,7 +82,9 @@ void declare_particle_system(py::module &m, std::string typestr) {
 		.def("state_velocity", &Class::stateVelocity, py::return_value_policy::reference)
 		.def("state_position", &Class::statePosition, py::return_value_policy::reference)
 		.def("state_force", &Class::stateForce, py::return_value_policy::reference)
-		.def("state_point_set", &Class::statePointSet, py::return_value_policy::reference);
+		.def("state_point_set", &Class::statePointSet, py::return_value_policy::reference)
+        //没找到对应的topology？我暂时用的是statePointSet替代跑通一下。。
+		.def("current_topology", &Class::statePointSet, py::return_value_policy::reference);
 }
 
 
@@ -124,6 +128,19 @@ void declare_func(py::module& m, std::string typestr) {
 	using Class = dyno::Attribute;
 }
 
+// class: CircularEmitter   - for example_2: Qt_WaterPouring
+template <typename TDataType>
+void declare_circular_emitter(py::module& m, std::string typestr) {
+	using Class = dyno::CircularEmitter<TDataType>;
+	using Parent = dyno::ParticleEmitter<TDataType>;
+	std::string pyclass_name = std::string("CircularEmitter") + typestr;
+	py::class_<Class, Parent, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def("var_location", &Class::varLocation, py::return_value_policy::reference);
+}
+
+
+
 void pybind_particle_system(py::module& m)
 {
 	declare_func(m, "");
@@ -144,5 +161,6 @@ void pybind_particle_system(py::module& m)
 
 	
 	declare_ghost_particlesm<dyno::DataType3f>(m, "3f");
+    
+	declare_circular_emitter<dyno::DataType3f>(m, "3f");
 }
-

--- a/python/PyRigidBodySystem.cpp
+++ b/python/PyRigidBodySystem.cpp
@@ -4,7 +4,7 @@
 #include "RigidBody/RigidBodyShared.h"
 
 using InstanceBase = dyno::InstanceBase;
-
+using namespace dyno;
 
 template <typename TDataType>
 void declare_rigid_body_system(py::module& m, std::string typestr) {
@@ -16,7 +16,9 @@ void declare_rigid_body_system(py::module& m, std::string typestr) {
 		.def(py::init<>())
 		.def("add_box", &Class::addBox)
 		.def("add_sphere", &Class::addSphere)
-		.def("add_tet", &Class::addTet);
+		.def("add_tet", &Class::addTet)
+		.def("current_topology", &Class::stateTopology, py::return_value_policy::reference)
+		.def("state_collisionMask", &Class::stateCollisionMask, py::return_value_policy::reference);
 }
 
 
@@ -50,10 +52,116 @@ void declare_box_info(py::module& m, std::string typestr) {
 		.def_readwrite("halfLength", &Class::halfLength);
 
 }
+
+
+void declare_sphere_info(py::module& m, std::string typestr) {
+	using Class = dyno::SphereInfo;
+
+	std::string pyclass_name = std::string("SphereInfo") + typestr;
+	py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def_readwrite("center", &Class::center)
+		.def_readwrite("radius", &Class::radius);
+
+}
+
+
+
+// class: TetInfo      - For Examples_1: QT_Bricks
+void declare_tet_info(py::module& m, std::string typestr) {
+	using Class = dyno::TetInfo;
+
+	std::string pyclass_name = std::string("TetInfo") + typestr;
+	py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+//		.def_readwrite("v", &Class::v); // "def_readwrite" is not applicable to fixed arrays,so replace it with the get-set method.
+		.def_property("v", &get_v, &set_v);
+}
+
+
+
+
+// class: TContactPair      - For Examples_1: QT_Bricks
+template<typename Real>
+void declare_collisionData_TContactPair(py::module& m, std::string typestr) {
+	using Class = dyno::TContactPair<Real>;
+
+	std::string pyclass_name = std::string("TContactPair") + typestr;
+	py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def(py::init<int, int, ContactType, Vector<Real, 3>, Vector<Real, 3>, Vector<Real, 3>, Vector<Real, 3>>())
+		.def_readwrite("bodyId1", &Class::bodyId1)
+		.def_readwrite("bodyId2", &Class::bodyId2)
+		.def_readwrite("interpenetration", &Class::interpenetration)
+		.def_readwrite("pos1", &Class::pos1)
+		.def_readwrite("pos2", &Class::pos2)
+		.def_readwrite("normal1", &Class::normal1)
+		.def_readwrite("normal2", &Class::normal2)
+		.def_readwrite("contactType", &Class::contactType);
+}
+
+
+// class: NeighborElementQuery      - For Examples_1: QT_Bricks  
+#include "Collision/NeighborElementQuery.h"
+template<typename TDataType>
+void declare_neighbor_element_query(py::module& m, std::string typestr) {
+	using Class = dyno::NeighborElementQuery<TDataType>;
+	std::string pyclass_name = std::string("NeighborElementQuery") + typestr;
+	py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def("in_discreteElements", &Class::inDiscreteElements,py::return_value_policy::reference)
+		.def("in_collisionMask", &Class::inCollisionMask, py::return_value_policy::reference)
+		.def("out_contacts", &Class::outContacts , py::return_value_policy::reference);
+}
+
+
+
+// class: ContactsToEdgeSet      - For Examples_1: QT_Bricks
+#include "Mapping/ContactsToEdgeSet.h"
+template<typename TDataType>
+void declare_contacts_to_edge_set(py::module& m, std::string typestr) {
+	using Class = dyno::ContactsToEdgeSet<TDataType>;
+	using Parent = dyno::TopologyMapping;
+
+	declare_collisionData_TContactPair<Real>(m, ""); //For inContacts:TContactPair<Real>
+
+	std::string pyclass_name = std::string("ContactsToEdgeSet") + typestr;
+	py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def("in_contacts", &Class::inContacts, py::return_value_policy::reference)
+		.def("var_scale", &Class::varScale, py::return_value_policy::reference)
+		.def("out_edgeSet", &Class::outEdgeSet, py::return_value_policy::reference);
+}
+
+
+
+// class: ContactsToPointSet3f      - For Examples_1: QT_Bricks
+#include "Mapping/ContactsToPointSet.h"
+template<typename TDataType>
+void declare_contacts_to_point_set(py::module& m, std::string typestr) {
+	using Class = dyno::ContactsToPointSet<TDataType>;
+	using Parent = dyno::TopologyMapping;
+	std::string pyclass_name = std::string("ContactsToPointSet") + typestr;
+	py::class_<Class, std::shared_ptr<Class>>(m, pyclass_name.c_str(), py::buffer_protocol(), py::dynamic_attr())
+		.def(py::init<>())
+		.def("in_contacts", &Class::inContacts, py::return_value_policy::reference)
+		.def("out_pointSet", &Class::outPointSet, py::return_value_policy::reference);
+}
+
+
+
+
 void pybind_rigid_body_system(py::module& m) {
 	declare_rigid_body_system<dyno::DataType3f>(m, "3f");
 
 	declare_rigid_body_info(m, "");
 	declare_box_info(m,"");
+	
+	declare_sphere_info(m, "");
+	declare_tet_info(m, "");
+
+	declare_neighbor_element_query<dyno::DataType3f>(m, "3f");
+	declare_contacts_to_edge_set<dyno::DataType3f>(m, "3f");
+	declare_contacts_to_point_set<dyno::DataType3f>(m, "3f");
 
 }

--- a/python/Testing/app_1_qtBricks.py
+++ b/python/Testing/app_1_qtBricks.py
@@ -1,0 +1,82 @@
+import PyPeridyno as dyno
+
+scn = dyno.SceneGraph()
+paticle = dyno.ParticleSystem3f()
+
+rigid = dyno.RigidBodySystem3f()
+scn.add_node(rigid)
+
+rigidBody = dyno.RigidBodyInfo()
+
+rigidBody.linear_velocity = dyno.Vector3f([0.5, 0, 0])
+box = dyno.BoxInfo()
+for i in range(8, 1, -1):
+    for j in range(i + 1):
+        box.center = dyno.Vector3f([0.5 * 0.5, 0.5 * (1.1 - 0.13 * i), 0.5 * (0.12 + 0.21 * j + 0.1 * (8 - i))])
+        box.half_length = dyno.Vector3f([0.5 * 0.065, 0.5 * 0.065, 0.5 * 0.1])
+        rigid.add_box(box, rigidBody, 1)
+
+sphere = dyno.SphereInfo()
+sphere.center = dyno.Vector3f([0.5, 0.75, 0.5])
+sphere.radius = 0.025
+
+rigidSphere = dyno.RigidBodyInfo() 
+rigid.add_sphere(sphere, rigidSphere, 1)
+
+sphere.center = dyno.Vector3f([0.5, 0.95, 0.5])
+sphere.radius = 0.025
+rigid.add_sphere(sphere, rigidSphere, 1)
+
+sphere.center = dyno.Vector3f([0.5, 0.65, 0.5])
+sphere.radius = 0.05
+rigid.add_sphere(sphere, rigidSphere, 1)
+
+
+tet = dyno.TetInfo()
+
+tet.v = [
+    dyno.Vector3f([0.5, 1.1, 0.5]),
+    dyno.Vector3f([0.5, 1.2, 0.5]),
+    dyno.Vector3f([0.6, 1.1, 0.5]),
+    dyno.Vector3f([0.5, 1.1, 0.6]),
+]
+rigid.add_tet(tet, rigidSphere, 1)
+
+
+mapper = dyno.DiscreteElementsToTriangleSet3f()
+rigid.current_topology().connect(mapper.in_discreteElements())
+rigid.graphics_pipeline().push_module(mapper)
+
+sRender = dyno.GLSurfaceVisualModule3f()
+sRender.set_color(dyno.Color(1, 1, 0))
+mapper.out_triangleSet().connect(sRender.in_triangleSet())
+rigid.graphics_pipeline().push_module(sRender)
+
+#todo:
+elementQuery = dyno.NeighborElementQuery3f()
+rigid.current_topology().connect(elementQuery.in_discreteElements())
+rigid.state_collisionMask().connect(elementQuery.in_collisionMask())
+rigid.graphics_pipeline().push_module(elementQuery)
+
+contactMapper = dyno.ContactsToEdgeSet3f()
+elementQuery.out_contacts().connect(contactMapper.in_contacts())
+contactMapper.var_scale().setValue(0.02)
+rigid.graphics_pipeline().push_module(contactMapper)
+
+
+wireRender = dyno.GLWireframeVisualModule() 
+wireRender.set_color(dyno.Color(0, 1, 0))
+contactMapper.out_edge_set().connect(wireRender.in_edgeSet()) 
+rigid.graphics_pipeline().push_module(wireRender) 
+
+
+
+pointRender = dyno.GLPointVisualModule() 
+pointRender.set_color(dyno.Color(1, 0, 0))
+contactPointMapper.out_pointSet().connect(pointRender.in_pointSet()) 
+rigid.graphics_pipeline().push_module(pointRender) 
+
+app = dyno.GLApp()
+app.set_scenegraph(scn)
+app.initialize(1280, 768, True)
+app.main_loop()

--- a/python/Testing/app_1_qtComputeDistance.py
+++ b/python/Testing/app_1_qtComputeDistance.py
@@ -1,0 +1,29 @@
+import PyPeridyno as dyno
+
+#createScene
+scn = dyno.SceneGraph()
+
+#为什么要在主函数里面定义Point\Distance，那我怎么去
+point  
+
+scn.add_node(point)
+scn.add_node(cube)
+scn.add_node(calculation)
+point.connect(calculation)
+cube.connect(calculation)
+
+
+mapper = dyno.DiscreteElementsToTriangleSet3f()
+rigid.current_topology().connect(mapper.in_discreteElements())
+rigid.graphics_pipeline().push_module(mapper)
+
+sRender = dyno.GLSurfaceVisualModule3f()
+sRender.set_color(dyno.Color(1, 1, 0))
+mapper.out_triangleSet().connect(sRender.in_triangleSet())
+rigid.graphics_pipeline().push_module(sRender)
+
+
+app = dyno.GLApp()
+app.set_scenegraph(scn)
+app.initialize(1280, 768, True)
+app.main_loop()

--- a/python/Testing/app_2_waterPouring.py
+++ b/python/Testing/app_2_waterPouring.py
@@ -1,0 +1,69 @@
+import PyPeridyno as dyno
+
+scn = dyno.SceneGraph()
+scn.set_gravity(dyno.Vector3f([0.0, -9.8, 0.0]))
+
+
+dyno.ModelingInitializer.modeling_init_static_plugin()
+dyno.ParticleSystemInitializer.paticleSystem_init_static_plugin()
+
+
+#createScene:
+
+#Create a particle emitter
+emitter = dyno.CircularEmitter3f()
+emitter.var_location().set_value(dyno.Vector3f([0.0, 1.0, 0.0]))
+
+#Particle fluid node
+fluid = dyno.ParticleFluid3f()
+emitter.connect(fluid.import_particles_emitters())
+
+ptRender = dyno.GLPointVisualModule()
+#ptRender.var_point_size().set_value(0.002) 
+ptRender.set_color(dyno.Color(1, 0, 0))
+ptRender.set_colorMapMode(ptRender.ColorMapMode.PER_VERTEX_SHADER)
+
+
+calculateNorm = dyno.CalculateNorm3f()
+colorMapper = dyno.ColorMapping3f()
+colorMapper.var_max().set_value(5.0)
+fluid.state_velocity().connect(calculateNorm.in_vec())
+calculateNorm.out_norm().connect(colorMapper.in_scalar())
+
+colorMapper.out_color().connect(ptRender.in_color())
+fluid.state_point_set().connect(ptRender.in_pointSet())
+
+fluid.graphics_pipeline().push_module(calculateNorm)
+fluid.graphics_pipeline().push_module(colorMapper)
+fluid.graphics_pipeline().push_module(ptRender)
+
+#fluid.animation_pipeline().disable()
+
+#Setup boundaries
+plane = dyno.PlaneModel3f()
+plane.var_scale().set_value(dyno.Vector3f([2.0, 0.0, 2.0]))
+scn.add_node(plane)
+
+sphere = dyno.SphereModel3f()
+sphere.var_location().set_value(dyno.Vector3f([0.0, 0.5, 0.0]))
+sphere.var_scale().set_value(dyno.Vector3f([0.2, 0.2, 0.2]))
+scn.add_node(sphere)
+
+merge = dyno.MergeTriangleSet3f()
+plane.state_triangleSet().connect(merge.in_first())
+sphere.state_triangleSet().connect(merge.in_second())
+scn.add_node(merge)
+
+#SFI node
+sfi = dyno.SemiAnalyticalSFINode3f()
+fluid.connect(sfi.import_particle_systems())
+merge.state_triangleSet().connect(sfi.in_triangleSet())
+
+
+
+
+    
+app = dyno.GLApp()
+app.set_scenegraph(scn)
+app.initialize(1280, 768, True)
+app.main_loop()

--- a/python/Testing/app_cloth.py
+++ b/python/Testing/app_cloth.py
@@ -16,7 +16,7 @@ scn.add_node(boundary)
 
 
 pointRender = dyno.GLPointVisualModule3f()
-pointRender.set_color(dyno.Vector3f([1, 0.2, 1]))
+pointRender.set_color(dyno.Color(1, 0.2, 1))
 pointRender.set_colorMapMode(pointRender.ColorMapMode.PER_OBJECT_SHADER)
 cloth.current_topology().connect(pointRender.in_pointSet())
 cloth.state_velocity().connect(pointRender.in_color())
@@ -31,5 +31,5 @@ cloth.graphics_pipeline().push_module(surfaceRenderer)
 
 app = dyno.GLApp()
 app.set_scenegraph(scn)
-app.create_window(1024, 768)
+app.initialize(1280, 768, True)
 app.main_loop()

--- a/python/Testing/app_elasticity.py
+++ b/python/Testing/app_elasticity.py
@@ -2,7 +2,7 @@ import PyPeridyno as dyno
 
 scn = dyno.SceneGraph()
 
-emitter = dyno.ParticleEmitterSquare3f()
+emitter = dyno.SquareEmitter3f()
 emitter.var_location().set_value(dyno.Vector3f([0.5, 0.5, 0.5]))
 scn.add_node(emitter)
 
@@ -18,7 +18,7 @@ calcNorm = dyno.CalculateNorm3f()
 colorMapper = dyno.ColorMapping3f()
 
 pointRender = dyno.GLPointVisualModule3f()
-pointRender.set_color(dyno.Vector3f([1, 0, 0]))
+pointRender.set_color(dyno.Color(1, 0, 0))
 pointRender.set_colorMapMode(pointRender.ColorMapMode.PER_VERTEX_SHADER)
 pointRender.set_colorMapRange(0, 5)
 
@@ -36,5 +36,5 @@ fluid.connect(boundary.import_particle_systems())
 
 app = dyno.GLApp()
 app.set_scenegraph(scn)
-app.create_window(800, 600)
+app.initialize(800, 600, True)
 app.main_loop()

--- a/python/Testing/app_particleFluid.py
+++ b/python/Testing/app_particleFluid.py
@@ -1,4 +1,5 @@
 import PyPeridyno as dyno
+import os
 
 scn = dyno.SceneGraph()
 
@@ -7,7 +8,14 @@ scn.set_lower_bound(dyno.Vector3f([-0.5, 0, -0.5]))
 
 boundary = dyno.StaticBoundary3f()
 boundary.load_cube(dyno.Vector3f([-0.5, 0, -0.5]), dyno.Vector3f([1.5, 2, 1.5]), 0.02, True)
-boundary.load_sdf("../../data/bowl/bowl.sdf", False)
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+relative_path = "../../data/bowl/bowl.sdf"
+file_path = os.path.join(script_dir, relative_path)
+if os.path.isfile(file_path):
+    boundary.load_sdf(file_path, False)
+else:
+    print(f"File not found: {file_path}")
 scn.add_node(boundary)
 
 fluid = dyno.ParticleFluid3f()
@@ -26,9 +34,9 @@ calcNorm.out_norm().connect(colorMapper.in_scalar())
 fluid.graphics_pipeline().push_module(colorMapper)
 
 ptRender = dyno.GLPointVisualModule3f()
-ptRender.set_color(dyno.Vector3f([1, 0, 0]))
+ptRender.set_color(dyno.Color(1, 0, 0))
 ptRender.set_colorMapMode(ptRender.ColorMapMode.PER_VERTEX_SHADER)
-ptRender.set_colorMapRange(0, 5)
+#ptRender.set_colorMapRange(0, 5)
 
 fluid.current_topology().connect(ptRender.in_pointSet())
 colorMapper.out_color().connect(ptRender.in_color())
@@ -44,5 +52,5 @@ fluid.connect(boundary.import_particle_systems())
 
 app = dyno.GLApp()
 app.set_scenegraph(scn)
-app.create_window(800, 600)
+app.initialize(800, 600,True)
 app.main_loop()

--- a/python/Testing/app_twoBoxes.py
+++ b/python/Testing/app_twoBoxes.py
@@ -22,12 +22,12 @@ rigid.current_topology().connect(mapper.in_discreteElements())
 rigid.graphics_pipeline().push_module(mapper)
 
 sRender = dyno.GLSurfaceVisualModule3f()
-sRender.set_color(dyno.Vector3f([1, 1, 0]))
+sRender.set_color(dyno.Color(1, 1, 0))
 mapper.out_triangleSet().connect(sRender.in_triangleSet())
 rigid.graphics_pipeline().push_module(sRender)
 
 
 app = dyno.GLApp()
 app.set_scenegraph(scn)
-app.create_window(1280, 768)
+app.initialize(1280, 768, True)
 app.main_loop()

--- a/src/Dynamics/Cuda/RigidBody/RigidBodyShared.h
+++ b/src/Dynamics/Cuda/RigidBody/RigidBodyShared.h
@@ -56,6 +56,23 @@ namespace dyno
 
 		Vector<Real, 3> v[4];
 	};
+	// Custom get and set functions for v member
+	static void set_v(TetInfo& obj, const std::vector<Vec3f>& values) {
+		if (values.size() != 4) {
+			throw std::runtime_error("TetInfo.v must be a list of 4 Vec3f elements.");
+		}
+		for (size_t i = 0; i < 4; ++i) {
+			obj.v[i] = values[i];
+		}
+	}
+
+	static std::vector<Vec3f> get_v(const TetInfo& obj) {
+		std::vector<Vec3f> values;
+		for (size_t i = 0; i < 4; ++i) {
+			values.push_back(obj.v[i]);
+		}
+		return values;
+	}
 
 	struct CapsuleInfo
 	{


### PR DESCRIPTION
**一、Update PyRigidBodySystem.cpp**`1）declare_rigid_body_system中增加了current_topology、state_collisionMask的绑定，但是state_collisionMask在python的Py_QTBricks例子中调用会报错：无法将dyno::FArray<dyno::CollisionMask,1>类型转换为Python类型。 2）增加了declare_sphere_info、declare_tet_info的绑定，在declare_tet_info的绑定中"def_readwrite"无法绑定固定数组v[4]，因此使用.def_property("v", &get_v, &set_v);，同时在"RigidBody/RigidBodyShared.h"中增加get和set静态函数，但不知道位置是否需要调整一下？ 3）最后在pybind_rigid_body_system的函数中调用新增加的绑定函数`

**二、Update PyParticleSystem.cpp**
1）增加了declare_circular_emitter绑定函数，同时增加了头文件#include "ParticleSystem/CircularEmitter.h"
2）补充了declare_particle_system，但是我没找到和current_topology的类，暂时用的是statePointSet替代跑通一下。

**三、Update PyFramework.cpp**
1）对照QTWaterpouring的例子新增了
declare_sphere_model、
declare_parametric_model、
declare_plane_model、
declare_merge_triangle_set
declare_semiAnalyticalSFI_node

2）对照example的时候发现有调用：
Modeling::initStaticPlugin();
ParticleSystem::initStaticPlugin();
SemiAnalyticalScheme::initStaticPlugin();
于是对应增加绑定了
①declare_modeling_init_static_plugin
②declare_paticleSystem_init_static_plugin
③declare_semiAnalyticalScheme_init_static_plugin
//第三个暂时有问题，获取不到SemiAnalyticalScheme::initStaticPlugin进行绑定，所以注释掉了。

3）最后在pybind_framework中增加了对应的绑定函数调用。

**四、Python testing**
修改：app_twoBoxes.py、app_particleFluid.py、app_elasticity.py、app_cloth.py
新增：app_1_qtBricks.py、app_2_waterPouring.py、app_1_qtComputeDistance.py