### PR TITLE
[codex] Adjust SIISPH density coupling

### DIFF
--- a/examples/Cuda/SemiAnalytical/SISPH_Cone/main.cpp
+++ b/examples/Cuda/SemiAnalytical/SISPH_Cone/main.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<SceneGraph> createScene()
 	auto solver = sfi->animationPipeline()->findFirstModule<SemiAnalyticalDensitySolver<DataType3f>>();
 	solver->varIterationNumber()->setValue(5);
 	solver->varMu()->setValue(1.0);
-	solver->varBoundaryFriction()->setValue(0.0001f);
+	solver->varBoundaryFriction()->setValue(0.000001f);
 	solver->varKappaLower()->setValue(100.0f);
 	solver->varPolynomialNumber()->setValue(5);
 	solver->varD_hat()->setValue(sfi->varSamplingDistance()->getValue() * 2);

--- a/src/Dynamics/Cuda/SemiAnalyticalScheme/Module/SemiAnalyticalDensitySolver.cu
+++ b/src/Dynamics/Cuda/SemiAnalyticalScheme/Module/SemiAnalyticalDensitySolver.cu
@@ -250,7 +250,7 @@ namespace dyno {
 		}
 		mPolyN[pId] = N;
 		// Warm-start: keep previous kappa as initial guess, but clamp to lower bound.
-		if (warmStart)	
+		if (warmStart)
 		{
 			outKappas[pId] = outKappas[pId] > KappaLower ? outKappas[pId] : KappaLower;
 		}
@@ -281,6 +281,7 @@ namespace dyno {
 		DArray<Coord> Kappas,
 		DArray<Coord> posBuf,	//in
 		DArray<Real> rho,		//in
+		DArray<Real> BoundaryDensity,
 		DArrayList<int> neighbors,	//in
 		Real smoothingLength,
 		Real mu,
@@ -292,11 +293,13 @@ namespace dyno {
 		if (pId >= posNext.size()) return;
 		Real rho_0 = Real(1000);
 
-		Real rho_i = rho[pId];
+		Real rho_i = rho[pId] - BoundaryDensity[pId];
 		rho_i = rho_i > rho_0 ? rho_i : rho_0;
+		Real bulk_rho_i = rho[pId];
+		bulk_rho_i = bulk_rho_i > rho_0 ? bulk_rho_i : rho_0;
 		Real A = mu * dt * dt / rho_0;
-
 		Real B_plus = rho_i / rho_0;
+		Real bulk_B_plus = bulk_rho_i / rho_0;
 		Real B_minus = Real(-1);
 
 		Coord pos_i = posBuf[pId];
@@ -333,7 +336,7 @@ namespace dyno {
 				posAcc_i += B_minus * a_ij * pos_j + B_plus * a_ij * (pos_j - pos_i);
 #endif // CONSERVE_MOMETNUM
 				a_i += B_minus * a_ij;
-				Kappas[pId] += (B_plus + B_minus) * a_ij * (pos_j - pos_i) / (dt * dt);
+				Kappas[pId] += (bulk_B_plus + B_minus) * a_ij * (pos_j - pos_i) / (dt * dt);
 			}
 		}
 #ifdef CONSERVE_MOMETNUM
@@ -1096,6 +1099,7 @@ namespace dyno {
 				mKappa,
 				mPosBuf,
 				this->outDensity()->getData(),
+				mCalculateDensity->outBoundaryDensity()->getData(),
 				this->inNeighborIds()->getData(),
 				h,
 				this->varMu()->getValue(),


### PR DESCRIPTION
## Summary
- Use fluid-only density for SIISPH fluid-particle position interaction while keeping full density for bulk kappa accumulation.
- Lower the SISPH_Cone boundary friction value to reduce cone-tip sticking artifacts.

## Root Cause
Boundary density compensation can be much larger near complex triangle features. Using the full density directly in fluid-fluid interaction can over-amplify the position update, while using only fluid density everywhere weakens the bulk response. This separates those two uses: fluid-fluid interaction uses the fluid density component, and kappa keeps the full density contribution.

## Validation
- Configured a clean worktree from peridyno/peridyno master.
- Built `SISPH_Cone` in Debug successfully:
  `cmake --build D:\codex_aux\peridyno_siisph_github\pr_siisph_density_20260616_build --config Debug --target SISPH_Cone -- /m:8`
- Logs: `D:\codex_aux\peridyno_siisph_github\pr_siisph_density_20260616_logs\build_SISPH_Cone.log`

## Notes
- The public `data` submodule URL returned HTTP 423 during full submodule update, so validation initialized only the build-required external submodules (`nodeeditor`, `stb`, `tinyobjloader`).